### PR TITLE
Downgrade pybind11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,9 +61,9 @@ class BuildExt(build_ext):
 setup(
     name='pdfrender',
     description='PDF Renderer',
-    version='0.3.1',
-    setup_requires=['pybind11>=2.2.4', 'Pillow>=4.3.0,<=6.2.2'],
-    install_requires=['pybind11>=2.2.4', 'Pillow>=4.3.0,<=6.2.2'],
+    version='0.3.2',
+    setup_requires=['pybind11>=2.2.3', 'Pillow>=4.3.0,<=6.2.2'],
+    install_requires=['pybind11>=2.2.3', 'Pillow>=4.3.0,<=6.2.2'],
     ext_modules=ext_modules,
     cmdclass={'build_ext': BuildExt},
     test_suite='tests',


### PR DESCRIPTION
Otherwise install breaks when deploying Shreddr.
Hopefully this solves the problem once and for all...

```
    Exception in thread Thread-1 (most likely raised during interpreter shutdown):Exception in thread Thread-2 (most likely raised during interpreter shutdown):
    Traceback (most recent call last):
    Traceback (most recent call last):
      File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
      File "/usr/lib/python2.7/threading.py", line 754, in run
      File "/usr/lib/python2.7/threading.py", line 754, in run
      File "/usr/lib/python2.7/multiprocessing/pool.py", line 330, in _handle_workers
    <type 'exceptions.TypeError'>: 'NoneType' object is not callable
    Exception TypeError: TypeError("'NoneType' object does not support item deletion",) in <Finalize object, dead>  File "/usr/lib/python2.7/multiprocessing/pool.py", line 366, in _handle_tasks
    <type 'exceptions.TypeError'>: 'NoneType' object is not callable
     ignored
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-NPDupv-build/setup.py", line 70, in <module>
        zip_safe=False,
      File "/usr/lib/python2.7/distutils/core.py", line 111, in setup
        _setup_distribution = dist = klass(attrs)
      File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 269, in __init__
        self.fetch_build_eggs(attrs['setup_requires'])
      File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 313, in fetch_build_eggs
        replace_conflicting=True,
      File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 826, in resolve
        dist = best[req.key] = env.best_match(req, ws, installer)
      File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 1085, in best_match
        dist = working_set.find(req)
      File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 695, in find
        raise VersionConflict(dist, req)
    pkg_resources.VersionConflict: (pybind11 2.2.3 (/usr/local/lib/python2.7/dist-packages), Requirement.parse('pybind11>=2.2.4'))
```
https://captricity.slack.com/archives/C11LXQQNB/p1589988757001500